### PR TITLE
Feat/Login setting-2

### DIFF
--- a/controllers/registrationController.js
+++ b/controllers/registrationController.js
@@ -1,0 +1,81 @@
+const User = require("../models/User");
+const { makeAccessToken, makeRefreshToken } = require("../utils/jwtUtils");
+const { COOKIE_MAX_AGE } = require("../utils/constants");
+
+const registrationController = async (req, res, next) => {
+  try {
+    const {
+      email,
+      displayName: userName,
+      photoURL: avatarUrl,
+      uid: googleId,
+      oauthAccessToken,
+      oauthRefreshToken,
+    } = req.body;
+
+    const findUser = await User.findOne({ email });
+
+    if (findUser) {
+      const accessToken = makeAccessToken(findUser._id);
+      const refreshToken = makeRefreshToken(findUser._id);
+
+      await User.findByIdAndUpdate(findUser._id, {
+        $set: {
+          refreshToken,
+          oauthAccessToken,
+          oauthRefreshToken,
+        },
+      });
+
+      res
+        .cookie("accessToken", accessToken, {
+          maxAge: COOKIE_MAX_AGE,
+          httpOnly: true,
+          secure: true,
+        })
+        .cookie("refreshToken", refreshToken, {
+          maxAge: COOKIE_MAX_AGE,
+          httpOnly: true,
+          secure: true,
+        })
+        .json({
+          success: true,
+          userInfo: { email: findUser.email, userName: findUser.userName },
+        });
+    } else {
+      const newUser = await User.create({
+        email,
+        userName,
+        avatarUrl,
+        googleId,
+        oauthAccessToken,
+        oauthRefreshToken,
+      });
+
+      const accessToken = makeAccessToken(newUser._id);
+      const refreshToken = makeRefreshToken(newUser._id);
+
+      await User.findByIdAndUpdate(newUser._id, { refreshToken });
+
+      res
+        .cookie("accessToken", accessToken, {
+          maxAge: COOKIE_MAX_AGE,
+          httpOnly: true,
+          secure: true,
+        })
+        .cookie("refreshToken", refreshToken, {
+          maxAge: COOKIE_MAX_AGE,
+          httpOnly: true,
+          secure: true,
+        })
+        .json({
+          success: true,
+          userInfo: { email: newUser.email, userName: newUser.userName },
+        });
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+module.exports = { registrationController };

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,11 +1,7 @@
 const createHttpError = require("http-errors");
 const User = require("../models/User");
 const { COOKIE_MAX_AGE } = require("../utils/constants");
-const {
-  makeAccessToken,
-  makeRefreshToken,
-  jwtVerifyToken,
-} = require("../utils/jwtUtils");
+const { makeAccessToken, jwtVerifyToken } = require("../utils/jwtUtils");
 
 const verifyToken = async (req, res, next) => {
   try {
@@ -14,7 +10,7 @@ const verifyToken = async (req, res, next) => {
     if (!accessToken && !refreshToken) {
       req.user = null;
 
-      return next(createHttpError(401, "Unauthorized"));
+      return next();
     }
 
     const decodedAccessToken = jwtVerifyToken(accessToken);
@@ -23,6 +19,9 @@ const verifyToken = async (req, res, next) => {
     if (!accessToken && refreshToken) {
       if (decodedRefreshToken.type) {
         const findUser = await User.findById(decodedRefreshToken.id);
+
+        req.user = findUser._id;
+
         const newAccessToken = makeAccessToken(findUser._id);
 
         res.status(201).cookie("accessToken", newAccessToken, {
@@ -36,24 +35,16 @@ const verifyToken = async (req, res, next) => {
       return next(createHttpError(401, "Unauthorized"));
     }
 
-    if (decodedAccessToken.message === "jwt expired") {
+    if (
+      !decodedAccessToken.type ||
+      decodedAccessToken.message === "jwt expired"
+    ) {
       if (decodedRefreshToken.type) {
-        const newAccessToken = makeAccessToken(decodedRefreshToken._id);
+        const findUser = await User.findById(decodedRefreshToken.id);
 
-        res.status(201).cookie("accessToken", newAccessToken, {
-          maxAge: COOKIE_MAX_AGE,
-          httpOnly: true,
-        });
+        req.user = findUser._id;
 
-        return next();
-      }
-
-      return next(createHttpError(401, "Unauthorized"));
-    }
-
-    if (!decodedAccessToken.type) {
-      if (decodedRefreshToken.type) {
-        const newAccessToken = makeAccessToken(decodedRefreshToken._id);
+        const newAccessToken = makeAccessToken(findUser._id);
 
         res.status(201).cookie("accessToken", newAccessToken, {
           maxAge: COOKIE_MAX_AGE,
@@ -68,10 +59,12 @@ const verifyToken = async (req, res, next) => {
 
     if (
       !decodedRefreshToken.type ||
-      decodedRefreshToken.message === "jwt expired"
+      decodedRefreshToken.message === "expired jwt"
     ) {
       return next(createHttpError(401, "Unauthorized"));
     }
+
+    req.user = decodedAccessToken.id;
 
     return next();
   } catch (error) {

--- a/models/User.js
+++ b/models/User.js
@@ -10,14 +10,14 @@ const userSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  avatarUrl: {
+    type: String,
+    required: true,
+  },
   googleId: {
     type: String,
     required: true,
     unique: true,
-  },
-  avatarUrl: {
-    type: String,
-    required: true,
   },
   projects: [
     {
@@ -25,13 +25,18 @@ const userSchema = new mongoose.Schema({
       ref: "Project",
     },
   ],
-  createdAt: {
-    type: Date,
-    default: Date.now,
-    required: true,
-  },
   refreshToken: {
     type: String,
+    unique: true,
+  },
+  oauthAccessToken: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  oauthRefreshToken: {
+    type: String,
+    required: true,
     unique: true,
   },
 });

--- a/routes/userRoute.js
+++ b/routes/userRoute.js
@@ -1,12 +1,9 @@
 const express = require("express");
-const { makeAccessToken, makeRefreshToken } = require("../utils/jwtUtils");
-const {
-  ACCESS_TOKEN_MAX_AGE,
-  REFRESH_TOKEN_MAX_AGE,
-} = require("../utils/constants");
-
 const User = require("../models/User");
 const { verifyToken } = require("../middlewares/authMiddleware");
+const {
+  registrationController,
+} = require("../controllers/registrationController");
 
 const route = express.Router();
 
@@ -19,70 +16,7 @@ route.get("/", (req, res, next) => {
   }
 });
 
-route.post("/login", async (req, res, next) => {
-  try {
-    console.log(req);
-    const {
-      email,
-      displayName: username,
-      photoURL: avatarUrl,
-      uid: googleId,
-    } = req.body;
-
-    const findUser = await User.findOne({ email });
-    if (findUser) {
-      const accessToken = makeAccessToken(findUser._id);
-      const refreshToken = makeRefreshToken(findUser._id);
-
-      await User.findByIdAndUpdate(findUser._id, { refreshToken });
-
-      res
-        .cookie("accessToken", accessToken, {
-          maxAge: ACCESS_TOKEN_MAX_AGE,
-          httpOnly: true,
-          secure: true,
-        })
-        .cookie("refreshToken", refreshToken, {
-          maxAge: REFRESH_TOKEN_MAX_AGE,
-          httpOnly: true,
-          secure: true,
-        })
-        .json({
-          success: true,
-          userInfo: { email: findUser.email, username: findUser.username },
-        });
-    } else {
-      const newUser = await User.create({
-        email,
-        username,
-        avatarUrl,
-        googleId,
-      });
-
-      const accessToken = makeAccessToken(newUser._id);
-      const refreshToken = makeRefreshToken(newUser._id);
-
-      await User.findByIdAndUpdate(newUser._id, { refreshToken });
-      res
-        .cookie("accessToken", accessToken, {
-          maxAge: ACCESS_TOKEN_MAX_AGE,
-          httpOnly: true,
-          secure: true,
-        })
-        .cookie("refreshToken", refreshToken, {
-          maxAge: REFRESH_TOKEN_MAX_AGE,
-          httpOnly: true,
-          secure: true,
-        })
-        .json({
-          success: true,
-          userInfo: { email: newUser.email, username: newUser.username },
-        });
-    }
-  } catch (error) {
-    console.log(error);
-  }
-});
+route.post("/login", registrationController);
 
 route.get("/validate", verifyToken, async (req, res, next) => {
   try {
@@ -90,7 +24,7 @@ route.get("/validate", verifyToken, async (req, res, next) => {
       const user = await User.findById(req.user);
 
       const userInfo = {
-        username: user.username,
+        userName: user.userName,
         userId: req.user,
       };
 

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,9 +1,11 @@
-const ACCESS_TOKEN_MAX_AGE = 60 * 1000;
-const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 1000;
+const COOKIE_MAX_AGE = 4 * 60 * 60 * 1000;
+const ACCESS_TOKEN_EXPIRES_IN = "1h";
+const REFRESH_TOKEN_EXPIRES_IN = "2h";
 const GOOGLE_SHEET_SCOPES = "https://www.googleapis.com/auth/spreadsheets";
 
 module.exports = {
-  ACCESS_TOKEN_MAX_AGE,
-  REFRESH_TOKEN_MAX_AGE,
+  COOKIE_MAX_AGE,
+  ACCESS_TOKEN_EXPIRES_IN,
+  REFRESH_TOKEN_EXPIRES_IN,
   GOOGLE_SHEET_SCOPES,
 };

--- a/utils/jwtUtils.js
+++ b/utils/jwtUtils.js
@@ -1,14 +1,14 @@
 const jwt = require("jsonwebtoken");
+const {
+  ACCESS_TOKEN_EXPIRES_IN,
+  REFRESH_TOKEN_EXPIRES_IN,
+} = require("./constants");
 
 const makeAccessToken = id => {
   try {
-    const token = jwt.sign(
-      {
-        id,
-      },
-      process.env.SECRET_KEY,
-      { expiresIn: "1h" },
-    );
+    const token = jwt.sign({ id }, process.env.SECRET_KEY, {
+      expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    });
 
     return token;
   } catch (error) {
@@ -16,26 +16,24 @@ const makeAccessToken = id => {
     return null;
   }
 };
+
 const makeRefreshToken = id => {
   try {
-    const token = jwt.sign(
-      {
-        id,
-      },
-      process.env.SECRET_KEY,
-      {
-        expiresIn: "14d",
-      },
-    );
+    const token = jwt.sign({ id }, process.env.SECRET_KEY, {
+      expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+    });
+
     return token;
   } catch (error) {
     console.log(error);
     return null;
   }
 };
+
 const jwtVerifyToken = token => {
   try {
     const user = jwt.verify(token, process.env.SECRET_KEY);
+
     return {
       type: true,
       id: user.id,


### PR DESCRIPTION
## 변경 사항
- [x] rejistrationController.js 추가
- [x] authMiddleware.js 수정
- [x] User Schema 수정
- [x] userRoute.js 수정
- [x] constants.js 수정
- [x] jwtUtils.js 수정

## 변경 사유

- userRoute 내부 로직을 controller 로 따로 분리하여 rejistrationController.js 파일로 분리했습니다.

- authMiddleware.js 내 사용하지 않는 `jwt` 삭제했습니다.

- authMiddleware.js 내 토큰의 유효성 및 만료 여부를 판단하여 새로 발급해주는 로직이 있습니다.

- 기존 로직에서는 조건이 통과될시 access 혹은 refresh 토큰을 직접 발급해주고 있습니다.

- 토큰을 말급해주는 유틸함수가 존재하기 때문에 이를 활용하는 방법으로 수정했습니다.

- 이렇게 수정하면 기존 토큰 새로 발급할 시에는 지정해주지 않았던 토큰의 `expiresIn` 속성까지 설정 가능해집니다.

- 토큰 유효성 검증 과정 수정 및 추가했습니다.


- User Schema 내 사용하지 않는 createAt 속성 삭제했습니다.

- User Schema 내 ouathAccessToken, oauthRefreshToken 을 추가했습니다.

- 추후 Google Spread Sheets 생성에 구글 소셜 로그인 성공 시 클라이언트가 받은 토큰들이 필요하기 때문입니다.

- userRoute.js 내 요청의 body 로 받는 데이터 중 username -> userName 으로 수정했습니다.

- 상수처리 파일인 constants.js 수정했습니다.

- 만료기간이 필요한 경우는 쿠키의 maxAge 속성, accessToken 와 refreshToken 의 expiresIn 속성 총 세가지 입니다. 

- 따라서 constants.js 내 변수명과 쿠키와 토큰의 속성명을 일치시켰습니다.

- 응답으로 res.cookie() 발급 시, maxAge 의 대상은 쿠기의 만료기간을 의미하므로 토큰의 유효기간에서 쿠키의 만료기간으로 수정했습니다.

- jwtUtils.js 내에서도 토큰 생성 시 위에서 상수처리한 값으로 각 토큰을 생성할 수 있도록 수정했습니다.

## 참고 사항
- 토큰 검증 과정에 대한 재검증 및 확인 후 추가완료