### PR TITLE
Feat/generate sheet url

### DIFF
--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -1,5 +1,59 @@
 const { google } = require("googleapis");
+const mongoose = require("mongoose");
+
 const User = require("../models/User");
+
+const getProject = async (req, res, next) => {
+  try {
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const validateDb = async (req, res, next) => {
+  try {
+    const {
+      body: { databaseUrl, databaseId, databasePassword },
+    } = req;
+    const URL = `mongodb+srv://${databaseId}:${databasePassword}@${databaseUrl}`;
+    const databaseConnection = mongoose.createConnection(URL);
+
+    databaseConnection.on("connected", async () => {
+      const databases = await databaseConnection.db.admin().listDatabases();
+      res.json({
+        success: true,
+        message: "Connected to database successfully",
+        databaseList: databases.databases,
+      });
+    });
+
+    databaseConnection.on("error", err => {
+      res.status(500).json({
+        success: false,
+        message: err.message,
+      });
+      databaseConnection.close();
+    });
+
+    process.on("unhandledRejection", (reason, promise) => {
+      console.log("Unhandled Rejection at:", promise, "reason:", reason);
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: "내부 서버 오류",
+    });
+  }
+};
+
+const validateSheet = async (req, res, next) => {
+  try {
+    console.log("validation sheet");
+  } catch (error) {
+    next(error);
+  }
+};
 
 const generateSheetUrl = async (req, res, next) => {
   try {
@@ -28,4 +82,4 @@ const generateSheetUrl = async (req, res, next) => {
   }
 };
 
-module.exports = { generateSheetUrl };
+module.exports = { getProject, generateSheetUrl, validateDb, validateSheet };

--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -1,0 +1,31 @@
+const { google } = require("googleapis");
+const User = require("../models/User");
+
+const generateSheetUrl = async (req, res, next) => {
+  try {
+    const findUser = await User.findById(req.user);
+    const auth = new google.auth.OAuth2();
+    auth.setCredentials({
+      access_token: findUser.oauthAccessToken,
+      refresh_token: findUser.oauthRefreshToken,
+    });
+    const sheets = google.sheets({ version: "v4", auth });
+    const response = await sheets.spreadsheets.create({
+      resource: {
+        properties: {
+          title: `${new Date().toISOString()} 스프레드시트`,
+        },
+      },
+    });
+    const {
+      data: { spreadsheetUrl: sheetUrl },
+    } = response;
+
+    res.json({ success: true, sheetUrl });
+  } catch (error) {
+    console.log(error);
+    next(error);
+  }
+};
+
+module.exports = { generateSheetUrl };

--- a/controllers/registrationController.js
+++ b/controllers/registrationController.js
@@ -20,11 +20,9 @@ const registrationController = async (req, res, next) => {
       const refreshToken = makeRefreshToken(findUser._id);
 
       await User.findByIdAndUpdate(findUser._id, {
-        $set: {
-          refreshToken,
-          oauthAccessToken,
-          oauthRefreshToken,
-        },
+        refreshToken,
+        oauthAccessToken,
+        oauthRefreshToken,
       });
 
       res

--- a/routes/projectRoute.js
+++ b/routes/projectRoute.js
@@ -1,13 +1,19 @@
 const express = require("express");
 
+const User = require("../models/User");
+const { verifyToken } = require("../middlewares/authMiddleware");
+const {
+  generateSheetUrl,
+  validateDb,
+  validateSheet,
+  getProject,
+} = require("../controllers/projectController");
+
 const route = express.Router();
 
-route.get("/", (req, res, next) => {
-  try {
-    res.send("Project router");
-  } catch (error) {
-    next(error);
-  }
-});
+route.get("/:id", getProject);
+route.post("/validation/db", validateDb);
+route.post("/validation/sheet", validateSheet);
+route.get("/generation/sheet", verifyToken, generateSheetUrl);
 
 module.exports = route;


### PR DESCRIPTION
close #11 

## 변경 사항
- [x] auth controller수정
- [x] generate sheet url controller 기능 생성
- [x] project route 에서 project controller로 기능 부분 모듈화

## 작업 내용

- 기존 유저의 정보를 수정하는 부분에 `$set`으로 설정되어 있어서 올바르게 수정되고 있지 않았습니다. 이부분 해결하였습니다.
- 작업한 내용을 구체적으로 설명할 수록 좋습니다.

## 변경 사유

- `$set`에 대한 이해가 필요할 듯 보입니다.
- [$set](https://mongoosejs.com/docs/api/document.html#Document.prototype.$set())
- 로그인시 파이어베이스를 통하여 로그인한 사용자의 구글 oauth2.0 로그인의 정보를 가저와서 디비에 저장한 후 구글시트 url을 생성하도록 만들었습니다. 파이어베이스에서 주는 토큰과 구글 oauth2.0에서 사용되는 토큰이 다르다는 점을 이해하였습니다.
- 기존 project route에 여러가지 로직이 있었는데 이들을 project controller로 모듈화하여 가독성을 높이고, 작업하는데 유용하도록 작업하였습니다.

## 참고 사항

- 종우님도 알고계시듯이, 파이어베이스에서 사용되는 토큰은 파이어베이스의 서비스만 사용할 수 있고 이 로그인을 통해 얻게되는 또 다른 _token의 값을 통하여 google oauth2.0에 접근하여 저희가 써야하는 google sheet 서비스를 사용할 수 있습니다.