### PR TITLE
Feat/handle user db data

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,7 +2,7 @@ const User = require("../models/User");
 const { makeAccessToken, makeRefreshToken } = require("../utils/jwtUtils");
 const { COOKIE_MAX_AGE } = require("../utils/constants");
 
-const registrationController = async (req, res, next) => {
+const login = async (req, res, next) => {
   try {
     const {
       email,
@@ -12,13 +12,11 @@ const registrationController = async (req, res, next) => {
       oauthAccessToken,
       oauthRefreshToken,
     } = req.body;
-
-    const findUser = await User.findOne({ email });
+    const findUser = await User.findOne({ email }).lean();
 
     if (findUser) {
       const accessToken = makeAccessToken(findUser._id);
       const refreshToken = makeRefreshToken(findUser._id);
-
       await User.findByIdAndUpdate(findUser._id, {
         refreshToken,
         oauthAccessToken,
@@ -38,7 +36,12 @@ const registrationController = async (req, res, next) => {
         })
         .json({
           success: true,
-          userInfo: { email: findUser.email, userName: findUser.userName },
+          userInfo: {
+            email: findUser.email,
+            userName: findUser.userName,
+            avatarUrl: findUser.avatarUrl,
+            userId: findUser._id,
+          },
         });
     } else {
       const newUser = await User.create({
@@ -49,7 +52,6 @@ const registrationController = async (req, res, next) => {
         oauthAccessToken,
         oauthRefreshToken,
       });
-
       const accessToken = makeAccessToken(newUser._id);
       const refreshToken = makeRefreshToken(newUser._id);
 
@@ -68,7 +70,12 @@ const registrationController = async (req, res, next) => {
         })
         .json({
           success: true,
-          userInfo: { email: newUser.email, userName: newUser.userName },
+          userInfo: {
+            email: newUser.email,
+            userName: newUser.userName,
+            avatarUrl: newUser.avatarUrl,
+            userId: newUser._id,
+          },
         });
     }
   } catch (error) {
@@ -76,4 +83,4 @@ const registrationController = async (req, res, next) => {
   }
 };
 
-module.exports = { registrationController };
+module.exports = { login };

--- a/models/TaskStatus.js
+++ b/models/TaskStatus.js
@@ -1,0 +1,15 @@
+const mongoose = require("mongoose");
+
+const taskStatusSchema = new mongoose.Schema({
+  statusId: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  message: {
+    type: String,
+    required: true,
+  },
+});
+
+module.exports = mongoose.model("TaskStatus", taskStatusSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -27,17 +27,14 @@ const userSchema = new mongoose.Schema({
   ],
   refreshToken: {
     type: String,
-    unique: true,
   },
   oauthAccessToken: {
     type: String,
     required: true,
-    unique: true,
   },
   oauthRefreshToken: {
     type: String,
     required: true,
-    unique: true,
   },
 });
 

--- a/routes/userRoute.js
+++ b/routes/userRoute.js
@@ -1,9 +1,7 @@
 const express = require("express");
 const User = require("../models/User");
 const { verifyToken } = require("../middlewares/authMiddleware");
-const {
-  registrationController,
-} = require("../controllers/registrationController");
+const { login } = require("../controllers/userController");
 
 const route = express.Router();
 
@@ -16,7 +14,7 @@ route.get("/", (req, res, next) => {
   }
 });
 
-route.post("/login", registrationController);
+route.post("/login", login);
 
 route.get("/validate", verifyToken, async (req, res, next) => {
   try {

--- a/utils/synchronizeUtils.js
+++ b/utils/synchronizeUtils.js
@@ -149,6 +149,7 @@ const synchronize = async (req, res) => {
     const { oauthAccessToken, oauthRefreshToken } = findUser;
 
     const result = await appendToSheet(
+      sheetUrl,
       dataToGoogle,
       oauthAccessToken,
       oauthRefreshToken,

--- a/utils/synchronizeUtils.js
+++ b/utils/synchronizeUtils.js
@@ -1,0 +1,165 @@
+const { google } = require("googleapis");
+const mongoose = require("mongoose");
+const TaskStatus = require("../models/TaskStatus");
+const User = require("../models/User");
+const { GOOGLE_SHEET_SCOPES } = require("./constants");
+
+const formatDbData = async collections => {
+  const data = [];
+  let columns = [];
+  let columnCounts = 0;
+
+  for (let i = 0; i < collections.length; i += 1) {
+    const eachCollection = collections[i];
+    const eachCollectionData = [];
+
+    for (let j = 0; j < eachCollection.length; j += 1) {
+      if (j === 0) {
+        columns = Object.keys(eachCollection[j]);
+        columnCounts = columns.length;
+
+        eachCollectionData.push(columns);
+      }
+
+      const rowCells = Object.values(eachCollection[j]);
+      const isCountsMatch = columnCounts === rowCells.length;
+
+      if (isCountsMatch) {
+        eachCollectionData.push(rowCells);
+      } else {
+        const eachRow = new Array(columnCounts).fill("");
+
+        for (let k = 0; k < columns.length; k += 1) {
+          const eachColumnCell = columns[k];
+
+          if (eachCollection[j][eachColumnCell]) {
+            eachRow[k] = eachCollection[j][eachColumnCell];
+          }
+        }
+
+        eachCollectionData.push(eachRow);
+      }
+    }
+
+    data.push(eachCollectionData);
+  }
+
+  return data;
+};
+
+const appendToSheet = async (
+  sheetUrl,
+  data,
+  oauthAccessToken,
+  oauthRefreshToken,
+) => {
+  function transformCellValue(value) {
+    if (typeof value === "object" && value instanceof Date) {
+      return value.toString();
+    }
+    if (typeof value === "object" && !Array.isArray(value)) {
+      return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+      return value.join(", ");
+    }
+    return value;
+  }
+
+  function transformDataForSheets(value) {
+    return value.map(row => row.map(cell => transformCellValue(cell)));
+  }
+
+  try {
+    const spreadSheetId = sheetUrl.match(/\/spreadsheets\/d\/(.*?)(\/|$)/)[1];
+
+    const auth = new google.auth.OAuth2({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      scopes: GOOGLE_SHEET_SCOPES,
+    });
+
+    auth.setCredentials({
+      access_token: oauthAccessToken,
+      refresh_token: oauthRefreshToken,
+    });
+
+    const sheets = google.sheets({ version: "v4", auth });
+    const transformedData = transformDataForSheets(data);
+
+    sheets.spreadsheets.values.append({
+      spreadsheetId: spreadSheetId,
+      range: "A1",
+      valueInputOption: "RAW",
+      resource: {
+        values: transformedData,
+      },
+    });
+  } catch (error) {
+    console.error("에러", error);
+
+    if (error.response && error.response.data && error.response.data.error) {
+      console.error("Google API 응답 에러:", error.response.data.error);
+      throw error;
+    }
+  }
+};
+
+const synchronize = async (req, res) => {
+  const {
+    body: { dbUrl, dbId, dbPassword, dbTableName, sheetUrl },
+  } = req;
+  const URL = `mongodb+srv://${dbId}:${dbPassword}@${dbUrl}/${dbTableName}`;
+  const databaseConnection = mongoose.createConnection(URL);
+  const fetchedData = [];
+
+  databaseConnection.on("connected", async () => {
+    const spreadsheetId = sheetUrl.match(/\/d\/(.+?)\//)[1];
+    const taskStatus = await TaskStatus.create({
+      statusId: spreadsheetId,
+      message: "CONNECTED_DB_DONE",
+    });
+
+    const selectedDatabase = databaseConnection.db;
+    const collections = await selectedDatabase.listCollections().toArray();
+
+    for (let i = 0; i < collections.length; i += 1) {
+      const collection = collections[i];
+      const collectionName = collection.name;
+      const eachData = selectedDatabase
+        .collection(collectionName)
+        .find()
+        .toArray();
+
+      fetchedData.push(eachData);
+    }
+
+    await TaskStatus.findByIdAndUpdate(taskStatus._id, {
+      message: "FETCH_DATA_DONE",
+    });
+
+    const collectionData = [...fetchedData];
+    const dataToGoogle = formatDbData(collectionData);
+
+    await TaskStatus.findByIdAndUpdate(taskStatus._id, {
+      message: "DATA_FORMATTING_DONE",
+    });
+
+    const findUser = await User.findById(req.user);
+    const { oauthAccessToken, oauthRefreshToken } = findUser;
+
+    const result = await appendToSheet(
+      dataToGoogle,
+      oauthAccessToken,
+      oauthRefreshToken,
+    );
+
+    await TaskStatus.findByIdAndUpdate(taskStatus._id, {
+      message: "TRANSFER_DATA_DONE",
+    });
+
+    res.json({ success: true, result });
+  });
+};
+
+module.exports = { synchronize };


### PR DESCRIPTION
close #12 

## 변경 사항
- [x] [request body](https://github.com/teamblend3/blend-dta-server/compare/dev...feat/handle-user-db?expand=1#diff-1fa1a128d1bd7813736db6965a717933cdfe8a0c577e8cf8c6b34e5dfc46737dR15-R18) 변경에 따른 변수명 수정
- [x] registerController 파일명 login 으로 변경
- [x] 사용자 프로필 이미지를 위한 [response 구조](https://github.com/teamblend3/blend-dta-server/compare/dev...feat/handle-user-db?expand=1#diff-04a689bd2ded7f5af5dc0bd5acac2079d50cd0dce7cf15f30cc0076749e6942cR39-R44) 변경

## 변경 사유
- 클라이언트 단 요청 시 변수명 수정에 따라 변경했습니다.
- 기존 registerController 가 수행하는 작업이 단순 사용자 등록이 아닌, 인증 후 로그인 동작을 하는 함수이기 때문에 더 명시적인 login 함수로 수정했습니다.
- 클라이언트 단에서 서버의 응답을 통해 프로필 사진을 변경할 수 있게 하기 위해서 response 내 변수명 변경했습니다.

## 작업 내용

- [x] synchronize 유틸 함수 생성
- [x] synchronize 를 통해 사용자의 DB에 fetch 하고, DB 내 데이터를 구글로 보내기 전에 알맞게 형 변환을 실행 후, Google API 에 맞는 조건을 설정하여 Google Spread Sheet 에 데이터를 작성하는 함수를 구분했습니다. 
- [x] 위 과정에서 작업 단계 별로 `TaskStatus` 상태를 업데이트 하여 클라이언트 단에서 단계마다 상태를 조회해 진행 과정을 살필 수 있도록 모델을 생성했습니다.

## 참고 사항
- synchronize 함수는 클라이언트 단 requset body 에 `dbUrl`, `dbPassword`, `dbTableName`, `sheetUrl` 정보가 담겨온다는 전제로 작성했습니다.
- 현재 라우터 파일로 분리해놓은 상태는 아닙니다.
- 현재 한 개의 collection 데이터만을 Google Spread Sheet 에 작성하는 로직입니다. 다른 collection 데이터를 구글 상 다른 sheet 에 작성할 수 있는 로직이 추가로 필요합니다.
- 리뷰 후 리팩토링 진행하겠습니다.

## Google Spread Sheet 변화 내용

<img width="1348" alt="스크린샷 2024-02-12 오후 2 02 22" src="https://github.com/teamblend3/blend-dta-server/assets/137036757/ebe10e94-28b5-42ba-87e9-d2e73bbacb53">