### PR TITLE
Refactor/synchronize-add collectionNames

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -88,14 +88,12 @@ const login = async (req, res, next) => {
 };
 
 const logout = async (req, res, next) => {
-  async (req, res, next) => {
-    try {
-      res.clearCookie("AccessToken", { httpOnly: true });
-      res.json({ success: true });
-    } catch (error) {
-      next(error);
-    }
-  };
+  try {
+    res.clearCookie("AccessToken", { httpOnly: true });
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
 };
 
 const getUserProfile = async (req, res, next) => {
@@ -111,7 +109,7 @@ const getUserProfile = async (req, res, next) => {
 
     const findUser = await User.findById(id);
 
-    return res.json({ success: true, findUser });
+    res.json({ success: true, findUser });
   } catch (error) {
     next(error);
   }
@@ -145,21 +143,21 @@ const editUserProfile = async (req, res, next) => {
         },
         { new: true },
       );
-      return res.json({ success: true, updatedUser });
+      res.json({ success: true, updatedUser });
+    } else {
+      const updatedUser = await User.findByIdAndUpdate(
+        id,
+        {
+          email,
+          userName,
+        },
+        { new: true },
+      );
+
+      console.log(updatedUser);
+
+      res.json({ success: true, updatedUser });
     }
-
-    const updatedUser = await User.findByIdAndUpdate(
-      id,
-      {
-        email,
-        userName,
-      },
-      { new: true },
-    );
-
-    console.log(updatedUser);
-
-    return res.json({ success: true, updatedUser });
   } catch (error) {
     next(error);
   }
@@ -167,12 +165,8 @@ const editUserProfile = async (req, res, next) => {
 
 const getUserProjects = async (req, res, next) => {
   try {
-    const {
-      user,
-      query: { page },
-    } = req;
+    const { user } = req;
 
-    const startIndex = (page - 1) * ITEMS_PER_PAGE;
     const findUser = await User.findById(user).populate({
       path: "projects",
       select: "title dbUrl sheetUrl collectionCount createdAt",
@@ -182,10 +176,7 @@ const getUserProjects = async (req, res, next) => {
     res.json({
       success: true,
       projectsLength: findUser.projects.length,
-      projects: findUser.projects.slice(
-        startIndex,
-        startIndex + ITEMS_PER_PAGE,
-      ),
+      projects: findUser.projects,
     });
   } catch (error) {
     next(error);


### PR DESCRIPTION
## 변경 사항
- [x] fetchFromDatabse import 삭제
- [x] taskStatus 객체 인덴팅 수정
- [x] collectionNames 선언 및 할당
- [x] createdAt 값 형 변형
- [x] appendToSheet 내 collectionNames parameter 추가
- [x] appendToSheet 유틸 함수 리팩토링

## 변경 사유
- 사용하지 않는 유틸 함수를 제거했습니다.
- 객체 내 인덴팅 잘못된 부분 있어 수정했습니다.
- appendToSheet 유틸 함수 기능 추가 및 수정했습니다. 기존 구글 스프레드 시트 내 데이터 입력 시, collection 이름이 아닌 `시트1`, `시트2` 형식으로 Tab 이름이 설정되고 있었습니다.
- Sheet 내 collection 이 많아질수록 각 Tab 이 나타내는 데이터를 구별할 필요가 있다고 판단, 각 Tab 이름을 collection 이름으로 설정해줬습니다.
- 따라서 collectioNames 를 `synchronize` 함수 내에서 선언하고 `appendToSheet` 유틸 함수에서 파라미터를 받아 설정할 수 있게끔 수정했습니다.