### PR TITLE
Refactor/add field to Project Model

### DIFF
--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -9,6 +9,7 @@ const {
   createMongoDbUrl,
   formatDbData,
   appendToSheet,
+  getDataPreview,
 } = require("../utils/synchronizeUtils");
 const { hashPassword } = require("../utils/typeConversionUtils");
 const { updateTaskStatus } = require("../utils/modelUtils");
@@ -93,6 +94,7 @@ const generateSheetUrl = async (req, res, next) => {
   try {
     const findUser = await User.findById(req.user);
     const auth = new google.auth.OAuth2();
+    auth.forceRefreshOnFailure = true;
 
     auth.setCredentials({
       access_token: findUser.oauthAccessToken,
@@ -165,6 +167,8 @@ const synchronize = async (req, res, next) => {
         collectionNames,
       );
 
+      const dataPreview = getDataPreview(collectionNames, fetchedData);
+
       const project = await Project.create({
         title: dbTableName,
         dbUrl,
@@ -172,6 +176,8 @@ const synchronize = async (req, res, next) => {
         dbPassword: await hashPassword(dbPassword),
         sheetUrl,
         collectionCount,
+        collectionNames,
+        dataPreview,
         createdAt: new Date().toISOString(),
         creator: user,
       });

--- a/models/Project.js
+++ b/models/Project.js
@@ -25,6 +25,18 @@ const projectSchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
+  collectionNames: [
+    {
+      type: String,
+      default: [],
+    },
+  ],
+  dataPreview: [
+    {
+      type: Object,
+      default: [],
+    },
+  ],
   createdAt: {
     type: Date,
     default: new Date(),

--- a/utils/synchronizeUtils.js
+++ b/utils/synchronizeUtils.js
@@ -117,9 +117,19 @@ const appendToSheet = async (
   }
 };
 
+const getDataPreview = (collectionNames, fetchedData) => {
+  const firstData = fetchedData.map(collection => collection[0]);
+  const dataPreview = collectionNames.map((collectionName, index) => ({
+    [collectionName]: firstData[index],
+  }));
+
+  return dataPreview;
+};
+
 module.exports = {
   createMongoDbUrl,
   fetchFromDatabase,
   formatDbData,
   appendToSheet,
+  getDataPreview,
 };


### PR DESCRIPTION
## Project Schema(dataPreiew)
![dataPreview_2](https://github.com/teamblend3/blend-dta-server/assets/137036757/e229d556-c323-429f-b122-8a77fed0a0a4)

## 작업 사항
- [x] Project Model 필드 추가
- [x] getDataPreview 함수 추가
- [x] projectController 내 `synchronize` 함수 수정

## 작업 내용

- [x] 각 project 가져오는 작업에서 필요할 데이터를 위해 Project Model 수정했습니다.
- [x] `/prjocts/:id` 페이지에서는 각 table 이 갖고 있는 모든 collectionNames, 각 collection 의 Schema 구조, data preview 를 알아야 합니다.
- [x] 이를 위해 Project Model 에 collectionNames, dataPreview 필드를 추가했습니다.
- [x] synchronize 함수 내에서 `fetchedData` 와 `collectionNames` 를 활용해 dataPreview 구조를 생성했습니다.
- [x] dataPreview 의 경우 각 table 이 갖고 있는 collection data 가 들어간 배열로서, 각 collection 데이터의 첫 번째 데이터만을 preview 의 형태로 보여주는 구조를 가집니다.(상단 사진 첨부 참조)

## 참고 사항
- 현재 사용자가 동일한 table 로 여러 project 를 만들 수 있는 것이 가능합니다. 하나의 table 로는 단일 project 만을 생성할 수 있도록 수정 작업 필요합니다.