### PR TITLE
Feat/change auth

### DIFF
--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -4,6 +4,8 @@ const mongoose = require("mongoose");
 const User = require("../models/User");
 const Project = require("../models/Project");
 const TaskStatus = require("../models/TaskStatus");
+const Log = require("../models/Log");
+
 const { getSheetIdIndex, isInvalidSheet } = require("../utils/validate");
 const {
   createMongoDbUrl,
@@ -11,7 +13,6 @@ const {
   appendToSheet,
 } = require("../utils/synchronizeUtils");
 const { hashPassword } = require("../utils/typeConversionUtils");
-const { updateTaskStatus } = require("../utils/modelUtils");
 const { STATUS_MESSAGE } = require("../utils/constants");
 const CustomError = require("../utils/customError");
 
@@ -21,6 +22,9 @@ const getProject = async (req, res, next) => {
       user,
       params: { id },
     } = req;
+    const findProject = await Project.findById(id);
+
+    res.json({ success: true, project: findProject });
   } catch (error) {
     next(error);
   }
@@ -62,7 +66,6 @@ const validateSheet = async (req, res, next) => {
     const {
       body: { sheetUrl },
     } = req;
-
     const splitBySlash = sheetUrl.split("/");
     const sheetIdIndex = getSheetIdIndex(splitBySlash);
     const invalidSheet = isInvalidSheet(sheetIdIndex, splitBySlash);
@@ -73,7 +76,7 @@ const validateSheet = async (req, res, next) => {
 
     const sheetId = splitBySlash[sheetIdIndex];
     const sheets = google.sheets({ version: "v4" });
-    const response = await sheets.spreadsheets.get({ sheetId });
+    const response = sheets.spreadsheets.get({ sheetId });
 
     if (!response || !response.data) {
       throw new CustomError("Spreadsheet not found", 404);
@@ -92,8 +95,12 @@ const validateSheet = async (req, res, next) => {
 const generateSheetUrl = async (req, res, next) => {
   try {
     const findUser = await User.findById(req.user);
-    const auth = new google.auth.OAuth2();
+    const auth = new google.auth.OAuth2(
+      process.env.CLIENT_ID,
+      process.env.CLIENT_SECRET,
+    );
 
+    auth.forceRefreshOnFailure = true;
     auth.setCredentials({
       access_token: findUser.oauthAccessToken,
       refresh_token: findUser.oauthRefreshToken,
@@ -113,7 +120,7 @@ const generateSheetUrl = async (req, res, next) => {
 
     res.json({ success: true, sheetUrl });
   } catch (error) {
-    throw new CustomError(error.message, 500);
+    next(new CustomError(error.message, 500));
   }
 };
 
@@ -123,7 +130,6 @@ const synchronize = async (req, res, next) => {
       user,
       body: { dbUrl, dbId, dbPassword, dbTableName, sheetUrl },
     } = req;
-
     const URL = createMongoDbUrl(dbId, dbPassword, dbUrl, dbTableName);
     const databaseConnection = mongoose.createConnection(URL);
     const spreadSheetId = sheetUrl.split("/d/")[1].split("/")[0];
@@ -131,32 +137,30 @@ const synchronize = async (req, res, next) => {
     databaseConnection.on("connected", async () => {
       const taskStatus = await TaskStatus.create({
         statusId: spreadSheetId,
-        message: "CONNECTED_DB_DONE",
+        message: STATUS_MESSAGE.CONNECTED,
       });
 
       const selectedDatabase = databaseConnection.db;
       const collections = await selectedDatabase.listCollections().toArray();
       const collectionNames = collections.map(collection => collection.name);
-
       const fetchDataPromises = collections.map(async collection => {
         const collectionName = collection.name;
         return selectedDatabase.collection(collectionName).find().toArray();
       });
 
       await TaskStatus.findByIdAndUpdate(taskStatus._id, {
-        message: "FETCH_DATA_DONE",
+        message: STATUS_MESSAGE.FETCHED,
       });
 
       const fetchedData = await Promise.all(fetchDataPromises);
       const dataToGoogle = await formatDbData(fetchedData);
 
       await TaskStatus.findByIdAndUpdate(taskStatus._id, {
-        message: "DATA_FORMATTING_DONE",
+        message: STATUS_MESSAGE.FORMATTED,
       });
 
       const findUser = await User.findById(req.user);
       const { oauthAccessToken, oauthRefreshToken } = findUser;
-
       const { collectionCount } = await appendToSheet(
         sheetUrl,
         dataToGoogle,
@@ -164,7 +168,6 @@ const synchronize = async (req, res, next) => {
         oauthRefreshToken,
         collectionNames,
       );
-
       const project = await Project.create({
         title: dbTableName,
         dbUrl,
@@ -177,12 +180,19 @@ const synchronize = async (req, res, next) => {
       });
 
       findUser.projects.push(project._id);
+
       await findUser.save();
 
       await TaskStatus.findByIdAndUpdate(taskStatus._id, {
-        message: "TRANSFER_DATA_DONE",
+        message: STATUS_MESSAGE.TRANSFERRED,
         project: project._id,
         createdAt: new Date().toISOString(),
+      });
+
+      await Log.create({
+        type: "CREATE",
+        message: "Project created successfully",
+        project: project._id,
       });
 
       res.json({ success: true });
@@ -192,10 +202,12 @@ const synchronize = async (req, res, next) => {
       await TaskStatus.findByIdAndUpdate(spreadSheetId, {
         message: "CONNECTED_DB_FALSE",
       });
+
       res.status(400).json({
         success: false,
         message: err.message,
       });
+
       databaseConnection.close();
     });
 
@@ -203,7 +215,6 @@ const synchronize = async (req, res, next) => {
       console.log("Unhandled Rejection at:", promise, "reason:", reason);
     });
   } catch (error) {
-    console.log("ERROR::", error);
     next(error);
   }
 };
@@ -214,7 +225,8 @@ const getTaskStatus = async (req, res, next) => {
       params: { id },
     } = req;
     const taskStatus = await TaskStatus.findOne({ statusId: id });
-    res.json({ success: true, status: taskStatus.message });
+
+    res.json({ success: true, status: taskStatus?.message });
   } catch (error) {
     next(error);
   }

--- a/models/TaskStatus.js
+++ b/models/TaskStatus.js
@@ -12,6 +12,7 @@ const taskStatusSchema = new mongoose.Schema({
   },
   message: {
     type: String,
+    default: "CONNECTED_DB_DONE",
   },
   createdAt: {
     type: Date,

--- a/utils/authUtils.js
+++ b/utils/authUtils.js
@@ -1,0 +1,85 @@
+import { google } from "googleapis";
+import { makeAccessToken, makeRefreshToken } from "./jwtUtils";
+import { COOKIE_MAX_AGE } from "./constants";
+
+export function configureOAuthClient() {
+  return new google.auth.OAuth2(
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    "http://localhost:5173",
+  );
+}
+
+export async function getOAuthTokens(code, auth) {
+  const { tokens } = await auth.getToken(code);
+  auth.setCredentials(tokens);
+  return tokens;
+}
+
+export async function fetchGoogleUserInfo(auth) {
+  const userAuth = google.oauth2({ auth, version: "v2" });
+  const { data } = await userAuth.userinfo.get();
+  return data;
+}
+
+export async function createUser(userInfo, tokens) {
+  return await User.create({
+    email: userInfo.email,
+    userName: userInfo.name,
+    avatarUrl: userInfo.picture,
+    googleId: userInfo.id,
+    oauthAccessToken: tokens.access_token,
+    oauthRefreshToken: tokens.refresh_token,
+  });
+}
+
+export async function updateUserTokens(userId, tokens) {
+  await User.findByIdAndUpdate(userId, {
+    oauthAccessToken: tokens.access_token,
+    oauthRefreshToken: tokens.refresh_token,
+  });
+}
+
+export function generateTokens(userId) {
+  return {
+    accessToken: makeAccessToken(userId),
+    refreshToken: makeRefreshToken(userId),
+  };
+}
+
+export function sendAuthCookies(res, accessToken, refreshToken) {
+  res
+    .cookie("accessToken", accessToken, {
+      maxAge: COOKIE_MAX_AGE,
+      httpOnly: true,
+      secure: true,
+    })
+    .cookie("refreshToken", refreshToken, {
+      maxAge: COOKIE_MAX_AGE,
+      httpOnly: true,
+      secure: true,
+    });
+}
+
+export function sendUserInfoResponse(res, user) {
+  res.json({
+    success: true,
+    userInfo: {
+      email: user.email,
+      userName: user.userName || user.name,
+      avatarUrl: user.avatarUrl || user.picture,
+      userId: user._id,
+    },
+  });
+}
+
+module.exports = {
+  configureOAuthClient,
+  getOAuthTokens,
+  fetchGoogleUserInfo,
+  createUser,
+  updateUserTokens,
+  generateTokens,
+  sendAuthCookies,
+  sendUserInfoResponse,
+};

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,14 +1,18 @@
 const COOKIE_MAX_AGE = 4 * 60 * 60 * 1000;
 const ACCESS_TOKEN_EXPIRES_IN = "1h";
 const REFRESH_TOKEN_EXPIRES_IN = "2h";
-const GOOGLE_SHEET_SCOPES = "https://www.googleapis.com/auth/spreadsheets";
+const GOOGLE_SHEET_SCOPES = [
+  "https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+];
 const SALT_ROUNDS = 10;
 const ITEMS_PER_PAGE = 5;
 const STATUS_MESSAGE = {
-  CONNECT: "CONNECTED_DB_DONE",
-  FETCH: "FETCH_DATA_DONE",
-  FORMAT: "FORMAT_DATA_DONE",
-  TRANSFER: "TRANSFER_DATA_DONE",
+  CONNECTED: "CONNECTED_DB_DONE",
+  FETCHED: "FETCH_DATA_DONE",
+  FORMATTED: "DATA_FORMATTING_DONE",
+  TRANSFERRED: "TRANSFER_DATA_DONE",
 };
 
 module.exports = {


### PR DESCRIPTION
## 변경 사항
- [x] login firebase -> google oauth2.0 으로 수정
- [x] auth util 작성
- [x] project controller 파일 수정

## 작업 내용

- 기존 firebase를 통해 로그인을 구현하였는데, 구글 로그인 oauth2.0을 통해 로그인 하는 것으로 변경하였습니다.
- 그 과정에서 login controller 리팩토링을 함께 진행하면서 auth utils 를 작성하여 비지니스 로직을 간소화 하였습니다.
- project 생성시 log 파일도 생성하여 create 하는 log를 만들도록 하였습니다.

## 변경 사유

- 기존 파이어베이스 로그인은 구글 api서비스를 사용하기 위한 엑세스 토큰은 반환하지만, 그 엑세스 토큰이 만료되었을때(1시간) 다시 갱신하는 refresh token은 반화하지 못하고 있었습니다. 조사 중 파이어베이스 로그인을 통해서는 구글 api 사용에 필요한 엑세스 토큰만 준다는 것을 알게되었고, 그렇게 되면 유저는 로그인 했을때로 부터 1시간 동안만, 서비스를 이용할 수 있게 되고, 그 후부터는 다시 로그인을 해야 하는 번거러움이 생기는 부분을 아예 구글 로그인으로 변경을 하여, 처음에 로그인할때 구글 서비스를 이용할 수 있는 엑세스 토큰과 리플레쉬 토큰을 받아, 로그인후 엑세스 토큰이 만료되어도 자동으로 리플레쉬 토큰을 통해 엑세스 토큰을 갱신하도록 변경하였습니다.
- 또한 로그인 비지니스 로직이 복잡하여 auth util 파일로 리팩토링 하였습니다.
- synchronize 하여 project를 만들시 log 파일을 생성하여 클라이언트 측에서 project detail 페이지로 이동시, project의 logs 를 보여주어야 하는데 그때 create 부터 부여주도록 하였습니다.