### PR TITLE
Feat/update google sheet data

### DIFF
--- a/utils/observerDbs.js
+++ b/utils/observerDbs.js
@@ -1,14 +1,17 @@
+const { google } = require("googleapis");
 const mongoose = require("mongoose");
+const User = require("../models/User");
 const Project = require("../models/Project");
+const Log = require("../models/Log");
 const { createMongoDbUrl } = require("./synchronizeUtils");
 const { decryptPassword } = require("./typeConversionUtils");
-const Log = require("../models/Log");
+const { GOOGLE_SHEET_SCOPES } = require("./constants");
 
 const observerDbs = async () => {
   const allProjects = await Project.find();
 
   allProjects.forEach(async project => {
-    const { title, dbId, dbPassword, dbUrl } = project;
+    const { title, dbId, dbPassword, dbUrl, sheetUrl } = project;
     const password = decryptPassword(dbPassword);
     const URL = createMongoDbUrl(dbId, password, dbUrl, title);
 
@@ -22,9 +25,76 @@ const observerDbs = async () => {
           operationDescription,
           ns: { coll },
           documentKey: { _id },
+          updateDescription: { updatedFields },
         } = change;
         console.log(change);
         const type = operationType.toUpperCase();
+
+        const findUser = await User.findOne({ projects: project._id });
+        const { oauthAccessToken, oauthRefreshToken } = findUser;
+        const spreadSheetId = sheetUrl.split("/d/")[1].split("/")[0];
+
+        const auth = new google.auth.OAuth2({
+          clientId: process.env.CLIENT_ID,
+          clientSecret: process.env.CLIENT_SECRET,
+          GOOGLE_SHEET_SCOPES,
+        });
+
+        auth.setCredentials({
+          access_token: oauthAccessToken,
+          refresh_token: oauthRefreshToken,
+        });
+
+        const sheetsClient = google.sheets({ version: "v4", auth });
+
+        const sheetsResponse = await sheetsClient.spreadsheets.values.get({
+          spreadsheetId: spreadSheetId,
+          range: coll,
+          valueRenderOption: "UNFORMATTED_VALUE",
+        });
+
+        const { values } = sheetsResponse.data;
+        const updatedRow = Object.keys(updatedFields)[0];
+        const updatedColumn = `"${_id.toString()}"`;
+        const updatedRowIndex = String.fromCharCode(
+          65 + values[0].indexOf(updatedRow),
+        );
+        const updatedColumnIndex =
+          values.findIndex(value => value[0] === updatedColumn) + 1;
+
+        const updateCellValue = async (
+          sheets,
+          spreadsheetId,
+          rowIndex,
+          columnIndex,
+          value,
+        ) => {
+          const range = `${coll}!${rowIndex}${columnIndex}`;
+
+          try {
+            const response = await sheets.spreadsheets.values.update({
+              spreadsheetId,
+              range,
+              valueInputOption: "RAW",
+              resource: {
+                values: [[value]],
+              },
+            });
+
+            console.log("셀 업데이트 완료:", response.data);
+          } catch (error) {
+            console.error("셀 업데이트 에러:", error);
+          }
+        };
+
+        const newData = Object.values(updatedFields)[0];
+        updateCellValue(
+          sheetsClient,
+          spreadSheetId,
+          updatedRowIndex,
+          updatedColumnIndex,
+          newData,
+        );
 
         await Log.create({
           type,


### PR DESCRIPTION
## 작업 내용
- [x] MongoDB observe 에 따른 Google Sheet 데이터 업데이트

## 작업 내용

- [x] 현재 `observeDbs` 함수 내에서 모든 Project 들의 변화 감지를 수행중입니다. 따라서 각 Project 의 SheetUrl 을 추적하였습니다.
- [x] 저희 User Model 의 projects 필드는 각 Project Model 을 참조하고 있기 때문에, 우선 `project._id` 를 통해 어떤 사용자가 만든 Project 인지를 추적했습니다.
- [x] 구글 API 를 사용하기 위해서 이를 통해 사용자의 oauthaccesstoken 과 oauthrefreshtoken 을 가져왔습니다.
- [x] 해당 정보를 통해 spreadSheet 의 데이터를 가져오면 기존 저희가 sheet 에 데이터를 입력했던 이차원 배열의 형태로 취득 가능합니다.
- [x] 이차원 배열의 첫 번째 배열은 각 필드 값, 이후의 배열들은 순서대로 각 데이터들의 value 값들을 나타내고 있습니다.
- [x] 감지된 변화는 선언된 `change` 변수를 통해 확인 가능합니다.
- [x]  이의 `._id` 속성은 해당 collection 내 각각의 데이터를 의미하며, 이는 Google Sheet 내에서 각 행으로서 표시됩니다.
- [x] `updateDescription` 속성은 각 Model 의 어떤 필드에서 변화가 일어났는지 확인 가능하며, 이는 Google Sheet 내에서 각 열로서 표시됩니다.
- [x] 이를 통해서 MongoDb 상 변화가 감지된 데이터가 Google Sheet 의 어느 셀에 위치하고 있는지에 대한 위치 파악이 가능해집니다.
- [x] 또한 change 에서 가져온 `coll` 속성을 통해 같은 시트 내에서 어떠한 collection 내에서 변화가 일어났는지에 대한 확인도 가능합니다.
- [x] 결론적으로 이렇게 확인한 위치 정보를 통해서 `spreadsheets.values.update` 를 통해 전체 시트 값을 업데이트 하는 것이 아닌 변경된 부분에 대해서만 데이터 업데이트가 가능해집니다.

## 참고 사항
- 아직 모듈화가 진행되지 않았습니다. 우선 observe 가 일어난 이후에 실행되어야 하는 동작들이기 때문에 회의 진행 후 리팩토링 진행하겠습니다.